### PR TITLE
BE-91: add endpoint for photosession result photos

### DIFF
--- a/sources/domain/domain_photosession/src/main/kotlin/photo/world/domain/photosession/service/DomainPhotosessionService.kt
+++ b/sources/domain/domain_photosession/src/main/kotlin/photo/world/domain/photosession/service/DomainPhotosessionService.kt
@@ -179,6 +179,19 @@ class DomainPhotosessionService(
         }
     }
 
+    override fun getResultPhotos(email: String, photosessionId: String): List<String> {
+        val photosession = photosessionRepository.getById(photosessionId)
+        val isParticipant = photosession.participants.any { it.email == email }
+            || photosession.organizer.email == email
+        if (isParticipant) {
+            return photosession.resultPhotos
+        } else {
+            throw ForbiddenException(
+                message = "Only participants can do this action, but user $email isn't a participant",
+            )
+        }
+    }
+
     private inline fun doActionIfOrganizer(
         userEmail: String,
         photosession: Photosession,

--- a/sources/domain/domain_photosession/src/main/kotlin/photo/world/domain/photosession/service/PhotosessionService.kt
+++ b/sources/domain/domain_photosession/src/main/kotlin/photo/world/domain/photosession/service/PhotosessionService.kt
@@ -84,4 +84,6 @@ interface PhotosessionService {
         photosessionId: String,
         photos: List<String>,
     )
+
+    fun getResultPhotos(email: String, photosessionId: String): List<String>
 }

--- a/sources/web/web_photosession/src/main/kotlin/photo/world/web/photosession/PhotosessionController.kt
+++ b/sources/web/web_photosession/src/main/kotlin/photo/world/web/photosession/PhotosessionController.kt
@@ -18,7 +18,7 @@ import java.util.*
 
 @RestController
 @RequestMapping("/api/v1/photosessions")
-class PhotosessionController(
+internal class PhotosessionController(
     private val photosessionService: PhotosessionService,
     private val photosessionTagsService: PhotosessionTagsService,
 ) {
@@ -192,6 +192,20 @@ class PhotosessionController(
             photos = request.photos,
         )
         return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/{photosessionId}/resultPhotos")
+    fun getResultPhotosession(
+        @PathVariable("photosessionId") photosessionId: String,
+        authentication: Authentication,
+    ): ResponseEntity<GetPhotosResponseDto> {
+        val photos = photosessionService.getResultPhotos(
+            email = authentication.name,
+            photosessionId = photosessionId,
+        )
+        return ResponseEntity.ok(
+            GetPhotosResponseDto(photos)
+        )
     }
 
     @PostMapping("/{photosessionId}/finish")

--- a/sources/web/web_photosession/src/main/kotlin/photo/world/web/photosession/dto/response/GetPhotosResponseDto.kt
+++ b/sources/web/web_photosession/src/main/kotlin/photo/world/web/photosession/dto/response/GetPhotosResponseDto.kt
@@ -1,0 +1,5 @@
+package photo.world.web.photosession.dto.response
+
+internal data class GetPhotosResponseDto(
+    val photos: List<String>,
+)


### PR DESCRIPTION
Закрыл задачу: [BE-91-add-endpoint-for-photosession-result-photos](https://www.notion.so/Add-endpoint-for-result-photos-in-photosession-4ae0c4f9ed0f4b15bcc4e8d739b84486?pvs=4)